### PR TITLE
Fix DCL

### DIFF
--- a/components/Exercise.js
+++ b/components/Exercise.js
@@ -1,0 +1,28 @@
+import React, { Component } from 'react';
+import Head from 'next/head'
+
+class Exercise extends Component {
+
+  componentDidMount () {
+    // The DOM manipulation inside DCL depends on angular.element being bound to
+    // a global jQuery instead of the built-in jqLite.
+    if (window) {
+      window.jQuery = require('jquery');
+      window.$ = window.jQuery;
+    }
+  };
+
+  render () {
+    return (
+      <div>
+        <Head>
+          <script src="http://localhost:3003/datacamp-light-latest.min.js"></script>
+        </Head>
+        {this.props.children}
+      </div>
+    );
+  }
+
+}
+
+export default Exercise;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "jquery": "^3.2.1",
     "next": "^3.2.2",
     "react": "^15.6.1",
     "react-dom": "^15.6.1"

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,38 +1,39 @@
 import Head from 'next/head'
 
+import Exercise from '../components/Exercise'
+
 const Index = () => (
   <div>
-    <Head>
-      <script src="https://cdn.datacamp.com/datacamp-light-latest.min.js"></script>
-    </Head>
-    <div data-datacamp-exercise data-lang="r">
-      <code data-type="pre-exercise-code">
-        # This will get executed each time the exercise gets initialized
-        b = 6
-      </code>
-      <code data-type="sample-code">
-        # Create a variable a, equal to 5
+    <Exercise>
+      <div data-datacamp-exercise data-lang="r">
+        <code data-type="pre-exercise-code">{`
+          # This will get executed each time the exercise gets initialized
+          b = 6`}
+        </code>
+        <code data-type="sample-code">
+          {`# Create a variable a, equal to 5
 
 
-        # Print out a
+# Print out a
 
+`}
+        </code>
+        <code data-type="solution">
+{`# Create a variable a, equal to 5
+a <- 5
 
-      </code>
-      <code data-type="solution">
-        # Create a variable a, equal to 5
-        a {`<-`} 5
-
-        # Print out a
-            print(a)
-      </code>
-      <code data-type="sct">
-        test_object("a")
-        test_function("print")
-        success_msg("Great job!")
-      </code>
-      <div data-type="hint">Use the assignment operator (<code>{`<-`}</code>) to create the variable <code>a</code>.</div>
-    </div>
+# Print out a
+print(a)`}
+        </code>
+        <code data-type="sct">
+{`test_object("a")
+test_function("print")
+success_msg("Great job!")`}
+        </code>
+        <div data-type="hint">Use the assignment operator (<code>{`<-`}</code>) to create the variable <code>a</code>.</div>
+      </div>
+    </Exercise>
   </div>
-)
+);
 
 export default Index

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,6 +2091,10 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
+jquery@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
+
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"


### PR DESCRIPTION
Changes made on this side:

- The DataCamp Light code requires `jQuery` (and `$`) to be globally defined. However, on the server side `window` doesn't exist (and it definitely doesn't transfer its contents to the client side). So, with these changes, jQuery is mounted in the global namespace when the component is mounted.
- React or next.js (I don't know which but it's not that important) remove the newlines from the HTML. So you can either write explicit `<br />`s or wrap the code in ``{`...`}``.

On the DataCamp Light side, the changes in that PR filter out the HTML that React adds inside the `<code>` tags; things like `<!-- react-text -->` and `<br data-reactid="..." />`, and prevents it from deleting the `<code>` tags (React breaks when it can't find one of its tags).

An ideal solution would be to better embed jQuery inside of DCL. But, since Angular depends on it [being in the global context](https://github.com/angular/angular.js/blob/3651e42e49ded7d410fd1cbd46f717056000afd4/src/Angular.js#L1903), that doesn't seem like an easy solution.